### PR TITLE
Fixes #1 - price separated by commas is not handled correctly

### DIFF
--- a/src/main/scala/io/kevinlee/parsers/Parsers.scala
+++ b/src/main/scala/io/kevinlee/parsers/Parsers.scala
@@ -25,7 +25,17 @@ object Parsers {
   val integral: P[Unit] = P(("0" | CharIn('1' to '9')) ~ digits.?)
 
   val numbers: P[BigDecimal] =
-    P(CharIn("+-").? ~ integral ~ factional.? ~ expondent.?).!.map(BigDecimal(_))
+    P(CharIn("+-").? ~ integral ~ factional.? ~ expondent.?).!.
+      map(BigDecimal(_))
+
+  /* digit,digit
+   * e.g.) 000,000 or 000
+   */
+  val monetaryDigits: P[Unit] = P(integral ~ ("," ~ integral.rep(min = 1)).?)
+
+  val monetaryNumbers: P[BigDecimal] =
+    P(CharIn("+-").? ~ monetaryDigits.rep(min = 1) ~ factional.? ~ expondent.?).!.
+      map(x => BigDecimal(x.replaceAllLiterally(",", "")))
 
 
   val Whitespace: CharToParse =

--- a/src/main/scala/io/kevinlee/pdf2excel/Pdf2Excel.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/Pdf2Excel.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory
 import fastparse.all._
 import fastparse.core.Parsed.Success
 import info.folone.scala.poi.{NumericCell, Row, Sheet, StringCell, Workbook}
-import io.kevinlee.parsers.Parsers.{alphabets, digits, numbers, spaces, stringChars}
+import io.kevinlee.parsers.Parsers.{alphabets, digits, monetaryNumbers, spaces, stringChars}
 import io.kevinlee.skala.strings.StringGlues._
 import net.ceedubs.ficus.Ficus._
 import org.apache.pdfbox.pdmodel.PDDocument
@@ -62,7 +62,7 @@ object Pdf2Excel {
                  case Success((dateProcessed, dateOfTransaction, cardNo, detailsAndAmount), _) =>
                    val splitted = detailsAndAmount.split("[\\s]+")
                    val last = splitted.last
-                   numbers.parse(last) match {
+                   monetaryNumbers.parse(last) match {
                      case Success(price, _) =>
                        acc :+ Transaction(dateProcessed, dateOfTransaction, cardNo, splitted.init.mkString(" "), price)
                      case _ =>


### PR DESCRIPTION
Fixes #1 - price separated by commas is not handled correctly
* added: monetaryNumbers parser to parse numbers separated by commas (e.g. 123,456,789)