### PR TITLE
Close #16 - Replace fastparse with cats-parse and use Cats instead of Scalaz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,4 @@
-//val dottyVersion = "0.20.0"
-//val ScalaVersion = "2.13.2"
-val ScalaVersion = "2.12.12"
-//val theScalaVersion = dottyVersion
+val ScalaVersion = "2.13.6"
 val theScalaVersion = ScalaVersion
 
 val CatsVersion = "2.2.0"
@@ -10,10 +7,10 @@ val PureConfigVersion = "0.13.0"
 val LogbackVersion = "1.2.3"
 val newtypeVersion = "0.4.4"
 
-val hedgehogVersion = "0.5.1"
+val hedgehogVersion = "0.7.0"
 
-val EffectieVersion = "1.4.0"
-val LoggerFVersion = "1.3.1"
+val EffectieVersion = "1.11.0"
+val LoggerFVersion = "1.11.0"
 
 val cats = "org.typelevel" %% "cats-core" % CatsVersion
 val catsEffect = "org.typelevel" %% "cats-effect" % CatsEffectVersion
@@ -27,43 +24,20 @@ lazy val loggerFCatsEffectSlf4j = Seq(
 ThisBuild / organization := "io.kevinlee"
 ThisBuild / version := "0.0.1"
 ThisBuild / scalaVersion := theScalaVersion
-ThisBuild / crossScalaVersions := Set(theScalaVersion, "2.11.12", "2.12.11", "2.13.2").toList
+ThisBuild / crossScalaVersions := Set(theScalaVersion, "2.12.13").toList
 
 lazy val root = (project in file("."))
   .settings(
-      name := "pdf2excel"
-    , wartremoverErrors ++= Warts.all
-    , scalacOptions ++= Seq(
-        "-deprecation"             // Emit warning and location for usages of deprecated APIs.
-      , "-feature"                 // Emit warning and location for usages of features that should be imported explicitly.
-      , "-unchecked"               // Enable additional warnings where generated code depends on assumptions.
-      , "-Xfatal-warnings"         // Fail the compilation if there are any warnings.
-      , "-Xlint"                   // Enable recommended additional warnings.
-      , "-Ywarn-adapted-args"      // Warn if an argument list is modified to match the receiver.
-      , "-Ywarn-dead-code"         // Warn when dead code is identified.
-      , "-Ywarn-inaccessible"      // Warn about inaccessible types in method signatures.
-      , "-Ywarn-nullary-override"  // Warn when non-nullary overrides nullary, e.g. def foo() over def foo.
-      , "-Ywarn-numeric-widen"     // Warn when numerics are widened.
-      ),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
-
-    resolvers += "3rd Party Repo" at "https://dl.bintray.com/kevinlee/maven",
+    name := "pdf2excel",
+    wartremoverErrors ++= Warts.allBut(Wart.ListUnapply),
     libraryDependencies ++= Seq(
         "org.apache.pdfbox" % "pdfbox" % "2.0.18",
 
-//        ("org.scalaz" %% "scalaz-core" % "7.2.23").withDottyCompat(scalaVersion.value),
-//        ("info.folone" %% "poi-scala" % "0.18").withDottyCompat(scalaVersion.value),
-//        ("com.lihaoyi" %% "fastparse"  % "1.0.0").withDottyCompat(scalaVersion.value),
-//        ("com.github.nscala-time" %% "nscala-time" % "2.18.0").withDottyCompat(scalaVersion.value),
-//        ("com.iheart" %% "ficus" % "1.4.3").withDottyCompat(scalaVersion.value),
-//        ("io.kevinlee" %% "skala" % "0.1.0").withDottyCompat(scalaVersion.value),
-
-        "org.scalaz" %% "scalaz-core" % "7.2.30",
-        "info.folone" %% "poi-scala" % "0.19",
-        "com.lihaoyi" %% "fastparse" % "1.0.0",
-        "com.github.nscala-time" %% "nscala-time" % "2.22.0",
-        "com.iheart" %% "ficus" % "1.4.7",
-        "io.kevinlee" %% "skala" % "0.1.0",
+        "info.folone" %% "poi-scala" % "0.20",
+        "org.typelevel" %% "cats-parse" % "0.3.3",
+        "com.github.nscala-time" %% "nscala-time" % "2.28.0",
+        "com.iheart" %% "ficus" % "1.5.0",
+        "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4",
       ) ++
       Seq(cats, catsEffect, effectieCatsEffect, newtype) ++
       loggerFCatsEffectSlf4j ++

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 //addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.4")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.15")
+addSbtPlugin("io.kevinlee" % "sbt-devoops" % "2.3.0")

--- a/src/main/scala/io/kevinlee/pdf2excel/cba/CbaPageHandler2.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/cba/CbaPageHandler2.scala
@@ -1,13 +1,11 @@
 package io.kevinlee.pdf2excel.cba
 
+import cats.parse.Parser.{Error => ParserError}
+import cats.parse.{Parser => P}
+import cats.syntax.all._
 import com.github.nscala_time.time.Imports.LocalDate
-
-import fastparse.all._
-
 import io.kevinlee.parsers.Parsers._
 import io.kevinlee.pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
-
-import scalaz._, Scalaz._
 
 import scala.annotation.tailrec
 
@@ -32,7 +30,7 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
 
   @tailrec
   def findTransactionStart(page: Seq[String]): Seq[String] = {
-    val droppedLines1 = page.dropWhile(line => line =/= transactionStart)
+    val droppedLines1 = page.dropWhile(line => line =!= transactionStart)
     if (droppedLines1.length < 2) {
       Vector.empty[String]
     } else {
@@ -45,7 +43,7 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
   private def decideYear(month: Int): Int = {
     val now = LocalDate.now()
     val year = now.getYear
-    if (month === 12 && now.getMonthOfYear =/= 12)
+    if (month === 12 && now.getMonthOfYear =!= 12)
       year - 1
     else
       year
@@ -58,18 +56,18 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
       None
     } else {
       val months =
-        Vector("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+        List("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
           .zipWithIndex.map { case (x, i) => (x, i + 1) }.toMap
 
-      val monthsP = P(StringIn(months.keys.toSeq:_*))
+      val monthsP = P.stringIn(months.keys)
 
-      val date = P(digits.rep.! ~ spaces.rep ~ monthsP.!).map { case (day, month) =>
+      val date = (digits.rep.string ~ (spaces.rep *> monthsP.string)).map { case (day, month) =>
         val monthValue = months(month)
-        LocalDate.parse(s"${decideYear(monthValue)}-$monthValue-$day")
+        LocalDate.parse(s"${decideYear(monthValue).toString}-${monthValue.toString}-${day.toString}")
       }
 
       val lineP =
-        date ~ spaces.rep ~ AnyChar.rep(1).! ~ End
+        date ~ (spaces.rep *> P.anyChar.rep(1).string) <* P.end
       val header = lines.headOption.map(buildHeader).getOrElse(Header("", "", "", ""))
 
       @tailrec
@@ -91,7 +89,7 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
               else {
                 val validBeforeNext = beforeNext.takeWhile { x =>
                   val y = x.trim
-                  !lastLines.exists(y.contains) && y =/= endMessage
+                  !lastLines.exists(y.contains) && y =!= endMessage
                 }
                 collect(next ++ xs.drop(5), acc :+ (line +: validBeforeNext.toVector).mkString(" "))
               }
@@ -104,10 +102,10 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
 
       def processLine(lines: Vector[String]): Vector[Transaction] = lines.flatMap { line =>
         lineP.parse(line) match {
-          case Parsed.Success((d, a), _) =>
+          case Right((_, (d, a))) =>
             val words = a.split("[\\s]+").map(_.trim)
             val (details, Array(amount)) = words.splitAt(words.length - 1)
-            val filteredAmount = amount.replaceAllLiterally(",", "")
+            val filteredAmount = amount.replace(",", "")
             Vector(
               Transaction(
                 d,
@@ -121,7 +119,7 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
                 )
               )
             )
-          case Parsed.Failure(_, _, _) =>
+          case Left(ParserError(_, _)) =>
             Vector.empty
         }
       }

--- a/src/main/scala/io/kevinlee/pdf2excel/data.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/data.scala
@@ -39,7 +39,7 @@ final case class TransactionDoc(header: Header, content: Seq[Transaction]) {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   lazy override val toString: String =
     s"""TransactionDoc(
-       |  $header,
+       |  ${header.toString},
        |  ${"-" * header.toString.length}
        |  ${content.mkString("", "\n  ", "\n")})
        |""".stripMargin


### PR DESCRIPTION
Close #16 - Replace `fastparse` with `cats-parse` and use Cats instead of Scalaz
- Also drop supporting Scala `2.11`