### PR TITLE
Fix #23 - `Intl Transaction Fee Rebate` removal for ING transaction doesn't work for the rebate appearing in another page

### DIFF
--- a/src/main/scala/io/kevinlee/pdf2excel/Pdf2Excel.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/Pdf2Excel.scala
@@ -19,12 +19,14 @@ object Pdf2Excel {
 
   def handlePages(
     f: Seq[String] => Option[TransactionDoc],
+    postProcess: Option[TransactionDoc => TransactionDoc],
     pages: List[Seq[String]]
   ): Option[TransactionDoc] = {
     val sequence: Option[List[TransactionDoc]] = pages.map(f).filter(_.isDefined).sequence
     val maybeDoc: Option[TransactionDoc] =
       sequence.flatMap(_.reduceLeftOption((x, y) => x.copy(content = x.content ++ y.content)))
-    maybeDoc
+
+    postProcess.fold(maybeDoc)(maybeDoc.map)
   }
 
 
@@ -117,7 +119,7 @@ object Pdf2Excel {
     // TODO: get it from parameter or config file
 //    val maybeDoc: Option[TransactionDoc] = handlePages(PageHandler1, pages)
 //    val maybeDoc: Option[TransactionDoc] = handlePages(CbaPageHandler2, pages)
-    val maybeDoc: Option[TransactionDoc] = handlePages(IngPageHandler, pages)
+    val maybeDoc: Option[TransactionDoc] = handlePages(IngPageHandler, (IngPageHandler.postProcess _).some, pages)
 
     maybeDoc match {
       case Some(transactionDoc) =>

--- a/src/main/scala/io/kevinlee/pdf2excel/ing/IngPageHandler.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/ing/IngPageHandler.scala
@@ -162,37 +162,42 @@ object IngPageHandler extends PageHandler[TransactionDoc] {
       val collected = collect(lines.drop(1), Vector.empty[String])
       val content = processLine(collected)
 
-      @scala.annotation.tailrec
-      def filterOutInternalTransactionFeeRebate(
-        transactions: Vector[Transaction],
-        acc: Vector[Transaction]
-      ): Vector[Transaction] = {
-        val firstTwo = transactions.take(2).toList
-        val rest     = transactions.drop(2)
-        firstTwo match {
-          case trans1 :: trans2 :: Nil =>
-            if (trans1.details === "Intl Transaction Fee" && trans2.details === "Intl Transaction Fee Rebate")
-              if (trans1.amount.abs - trans2.amount.abs === BigDecimal(0))
-                filterOutInternalTransactionFeeRebate(rest, acc)
-              else
-                filterOutInternalTransactionFeeRebate(rest, acc :+ trans1 :+ trans2)
+      TransactionDoc(header, content).some
+    }
+  }
+
+  def postProcess(transactionDoc: TransactionDoc): TransactionDoc = {
+
+    @scala.annotation.tailrec
+    def filterOutInternalTransactionFeeRebate(
+      transactions: Vector[Transaction],
+      acc: Vector[Transaction]
+    ): Vector[Transaction] = {
+      val firstTwo = transactions.take(2).toList
+      val rest = transactions.drop(2)
+      firstTwo match {
+        case trans1 :: trans2 :: Nil =>
+          if (trans1.details.trim === "Intl Transaction Fee" && trans2.details.trim === "Intl Transaction Fee Rebate")
+            if (trans1.amount.abs - trans2.amount.abs === BigDecimal(0))
+              filterOutInternalTransactionFeeRebate(rest, acc)
             else
-              filterOutInternalTransactionFeeRebate(trans2 +: rest, acc :+ trans1)
+              filterOutInternalTransactionFeeRebate(rest, acc :+ trans1 :+ trans2)
+          else
+            filterOutInternalTransactionFeeRebate(trans2 +: rest, acc :+ trans1)
 
-          case _ :: _ :: _ =>
-            sys.error(
-              "This is a bug in filterOutInternalTransactionFeeRebate!!! filtering should never reach this pattern."
-            )
+        case _ :: _ :: _ =>
+          sys.error(
+            "This is a bug in filterOutInternalTransactionFeeRebate!!! filtering should never reach this pattern."
+          )
 
-          case trans :: Nil =>
-            acc :+ trans
+        case trans :: Nil =>
+          acc :+ trans
 
-          case Nil =>
-            acc
-        }
+        case Nil =>
+          acc
       }
 
-      TransactionDoc(header, filterOutInternalTransactionFeeRebate(content, Vector.empty)).some
     }
+    transactionDoc.copy(content = filterOutInternalTransactionFeeRebate(transactionDoc.content.toVector, Vector.empty[Transaction]))
   }
 }


### PR DESCRIPTION
Fix #23 - `Intl Transaction Fee Rebate` removal for ING transaction doesn't work for the rebate appearing in another page

- Now post process to remove "`Intl Transaction Fee Rebate`" is done after merging all transaction pages