### PR TITLE
Bump Scala, sbt, sbt-plugins and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val root = (project in file("."))
 
 lazy val props = new {
   //  final val ScalaVersion    = "3.0.0"
-  final val ScalaVersion        = "2.13.6"
+  final val ScalaVersion        = "2.13.11"
   final val ProjectScalaVersion = ScalaVersion
 
   final val Org            = "io.kevinlee"
@@ -36,24 +36,24 @@ lazy val props = new {
 
   final val CatsVersion       = "2.9.0"
   final val CatsEffectVersion = "2.5.5"
-  final val PureConfigVersion = "0.16.0"
-  final val LogbackVersion    = "1.2.3"
+  final val PureConfigVersion = "0.17.4"
+  final val LogbackVersion    = "1.4.8"
   final val NewtypeVersion    = "0.4.4"
 
   final val HedgehogVersion = "0.10.1"
 
-  final val EffectieVersion = "2.0.0-beta5"
-  final val LoggerFVersion  = "2.0.0-beta6"
+  final val EffectieVersion = "2.0.0-beta9"
+  final val LoggerFVersion  = "2.0.0-beta12"
 
-  val ExtrasVersion = "0.28.0"
+  val ExtrasVersion = "0.39.0"
 
-  final val PdfboxVersion     = "2.0.18"
-  final val PoiScalaVersion   = "0.20"
-  final val CatsParseVersion  = "0.3.3"
-  final val NscalaTimeVersion = "2.28.0"
-  final val FicusVersion      = "1.5.0"
+  final val PdfboxVersion     = "2.0.28"
+  final val PoiScalaVersion   = "0.23"
+  final val CatsParseVersion  = "0.3.9"
+  final val NscalaTimeVersion = "2.32.0"
+  final val FicusVersion      = "1.5.2"
 
-  final val ScalaCollectionCompatVersion = "2.4.4"
+  final val ScalaCollectionCompatVersion = "2.11.0"
 }
 
 lazy val libs = new {
@@ -73,8 +73,8 @@ lazy val libs = new {
   )
 
   lazy val extrasAll = List(
-    "io.kevinlee" %% "extras-cats"       % props.ExtrasVersion,
-    "io.kevinlee" %% "extras-refinement" % props.ExtrasVersion,
+    "io.kevinlee" %% "extras-cats"   % props.ExtrasVersion,
+    "io.kevinlee" %% "extras-render" % props.ExtrasVersion,
   )
 
   lazy val pdfbox                = "org.apache.pdfbox"       % "pdfbox"      % props.PdfboxVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.9.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,8 @@
 //addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.4")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.15")
-addSbtPlugin("io.kevinlee"     % "sbt-devoops"     % "2.20.0")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.3")
+
+val SbtDevOopsVersion = "2.24.0"
+addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % SbtDevOopsVersion)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % SbtDevOopsVersion)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % SbtDevOopsVersion)

--- a/src/main/scala/io/kevinlee/parsers/Parsers.scala
+++ b/src/main/scala/io/kevinlee/parsers/Parsers.scala
@@ -3,6 +3,8 @@ package io.kevinlee.parsers
 import cats.parse.{Parser => P, _}
 import cats.parse.Parser.{Error => ParserError}
 
+import scala.annotation.nowarn
+
 /** @author Kevin Lee
   * @since 2018-03-04
   */
@@ -31,6 +33,7 @@ object Parsers {
 
   val expondent: P[Unit] = (P.charIn("eE") ~ P.charIn("+-").? ~ digits).void
   val factional: P[Unit] = (P.charIn(".") ~ digits.rep).void
+  @nowarn(value ="msg=a type was inferred to be `AnyVal`; this may indicate a programming error.")
   val integral: P[Unit]  = ((P.char('0') | P.charIn('1' to '9')) ~ digits.?).void
 
   val numbers: Parser0[BigDecimal] =
@@ -81,6 +84,7 @@ object Parsers {
   val unicodeEscape: P[Unit] = (P.char('u') ~ hexDigit ~ hexDigit ~ hexDigit ~ hexDigit).void
 
   @SuppressWarnings(Array("org.wartremover.warts.JavaSerializable", "org.wartremover.warts.Serializable"))
+  @nowarn(value = "msg=a type was inferred to be `AnyVal`; this may indicate a programming error.")
   val escape: P[Any] =
     (P.string("""\""") ~ (P.charIn("""/"\bfnrt""") | unicodeEscape)) | P.string("''").map(_ => "'")
 

--- a/src/main/scala/io/kevinlee/pdf2excel/Pdf2Excel.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/Pdf2Excel.scala
@@ -22,9 +22,9 @@ object Pdf2Excel {
 
   final case class FromTo(from: Int, to: Int)
 
-  def apply[F[*]: Fx: Monad: ResourceMaker: ConsoleEffect]: Pdf2Excel[F] = new Pdf2ExcelF[F]
+  def apply[F[*]: Fx: Monad: ResourceMaker]: Pdf2Excel[F] = new Pdf2ExcelF[F]
 
-  final private class Pdf2ExcelF[F[*]: Fx: Monad: ResourceMaker: ConsoleEffect] extends Pdf2Excel[F] {
+  final private class Pdf2ExcelF[F[*]: Fx: Monad: ResourceMaker] extends Pdf2Excel[F] {
 
     def handlePages(
       f: Seq[String] => Option[TransactionDoc],

--- a/src/main/scala/io/kevinlee/pdf2excel/Pdf2ExcelApp.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/Pdf2ExcelApp.scala
@@ -19,7 +19,6 @@ object Pdf2ExcelApp extends IOApp.Simple {
     val outputPath    = s"$outputDir/${replaceFileExtension(inputFile.getName, "xls")}"
 
     import effectie.instances.ce2.fx._
-    import effectie.instances.console._
 
     implicit val resourceMaker: ResourceMaker[IO] = Ce2ResourceMaker.forAutoCloseable[IO]
 

--- a/src/main/scala/io/kevinlee/pdf2excel/cba/CbaPageHandler.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/cba/CbaPageHandler.scala
@@ -28,7 +28,7 @@ case object CbaPageHandler extends PageHandler[TransactionDoc] {
   @tailrec
   def findTransactionStart(page: Seq[String]): Seq[String] = {
     val droppedLines1 = page.dropWhile(line => line =!= transactionStart)
-    if (droppedLines1.length < 2) {
+    if (droppedLines1.lengthIs < 2) {
       Vector.empty[String]
     } else {
       val lines = droppedLines1.drop(1)
@@ -79,7 +79,7 @@ case object CbaPageHandler extends PageHandler[TransactionDoc] {
           lineP.parse(line) match {
             case Right((_, (d, a))) =>
               val (twoMoreLines, rest) = xs.splitAt(2)
-              if (twoMoreLines.length === 2 && twoMoreLines(1).trim.startsWith("Mastercard")) {
+              if (twoMoreLines.length === 2 && twoMoreLines.drop(1).headOption.fold(false)(_.trim.startsWith("Mastercard"))) {
                 processLine(s"$line ${twoMoreLines.map(_.trim).mkString(" ")}" :: rest, acc)
               } else {
                 val words                          = a.split("[\\s]+").map(_.trim)

--- a/src/main/scala/io/kevinlee/pdf2excel/cba/CbaPageHandler2.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/cba/CbaPageHandler2.scala
@@ -31,7 +31,7 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
   @tailrec
   def findTransactionStart(page: Seq[String]): Seq[String] = {
     val droppedLines1 = page.dropWhile(line => line =!= transactionStart)
-    if (droppedLines1.length < 2) {
+    if (droppedLines1.lengthIs < 2) {
       Vector.empty[String]
     } else {
       val lines = droppedLines1.drop(1)
@@ -66,7 +66,7 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
       val date = (digits.rep.string ~ (spaces.rep *> monthsP.string)).map {
         case (day, month) =>
           val monthValue = months(month)
-          LocalDate.parse(s"${decideYear(monthValue).toString}-${monthValue.toString}-${day.toString}")
+          LocalDate.parse(s"${decideYear(monthValue).toString}-${monthValue.toString}-$day")
       }
 
       val lineP  =

--- a/src/main/scala/io/kevinlee/pdf2excel/ing/IngPageHandler.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/ing/IngPageHandler.scala
@@ -32,7 +32,7 @@ object IngPageHandler extends PageHandler[TransactionDoc] {
   @tailrec
   private def findTransactionStart(page: Seq[String]): Seq[String] = {
     val droppedLines1 = page.dropWhile(line => line =!= transactionStart)
-    val lines         = if (droppedLines1.length < 2) {
+    val lines         = if (droppedLines1.lengthIs < 2) {
       @SuppressWarnings(Array("org.wartremover.warts.PlatformDefault"))
       val (_, transactionLists) =
         page.span(line =>
@@ -45,7 +45,7 @@ object IngPageHandler extends PageHandler[TransactionDoc] {
     } else {
       droppedLines1.drop(1)
     }
-    if (lines.length < 2) {
+    if (lines.lengthIs < 2) {
       Vector.empty[String]
     } else {
       val found = lines.headOption.exists(_.trim.startsWith("Date"))

--- a/src/main/scala/io/kevinlee/pdf2excel/nab/NabPageHandler.scala
+++ b/src/main/scala/io/kevinlee/pdf2excel/nab/NabPageHandler.scala
@@ -14,9 +14,12 @@ case object NabPageHandler extends PageHandler[TransactionDoc] {
   val transactionStart: String = "Transaction details"
 
   def buildHeader(header: Seq[String]): Header = {
-    val dateProcessed     = s"${header(0)} ${header(1)}"
-    val dateOfTransaction = s"${header(2)} ${header(3)}"
-    val rest              = header(5).split("[\\s]+")
+//    val dateProcessed     = s"${header(0)} ${header(1)}"
+    val dateProcessed     = (header.headOption |+| " ".some |+| header.drop(1).headOption).fold("")(_.trim)
+//    val dateOfTransaction = s"${header(2)} ${header(3)}"
+    val dateOfTransaction = (header.drop(2).headOption |+| " ".some |+| header.drop(3).headOption).fold("")(_.trim)
+//    val rest              = header(5).split("[\\s]+")
+    val rest              = header.drop(5).headOption.fold(Array.empty[String])(_.split("[\\s]+"))
 //    val cardNo = s"${header(4)} ${rest(0)}"
     val details           = rest(1)
     val amount            = s"${rest(2)} ${rest(3)}"


### PR DESCRIPTION
Bump Scala, sbt, sbt-plugins and libraries
- Scala to 2.13.11
- sbt to 1.9.0 = sbt-wartremover to 3.1.3 = sbt-devoops to 2.24.0
- sbt plugins
- pureconfig to 0.17.4
- logback to 1.4.8
- effectie to 2.0.0-beta9
- logger-f to 2.0.0-beta12
- extras 0.39.0
- pdfbox to 2.0.28
- poi-scala to 0.23
- cats-parse to 0.3.9
- nscala-time to 2.32.0
- ficus to 1.5.2
- scala-collection-compat to 2.11.0