### PR TITLE
Rename packages `io.kevinlee.parsers` => `kevinlee.parsers` / `io.kevinlee.pdf2excel` => `pdf2excel`

### DIFF
--- a/src/main/scala/kevinlee/parsers/Parsers.scala
+++ b/src/main/scala/kevinlee/parsers/Parsers.scala
@@ -1,4 +1,4 @@
-package io.kevinlee.parsers
+package kevinlee.parsers
 
 import cats.parse.{Parser => P, _}
 import cats.parse.Parser.{Error => ParserError}

--- a/src/main/scala/pdf2excel/Pdf2Excel.scala
+++ b/src/main/scala/pdf2excel/Pdf2Excel.scala
@@ -1,4 +1,4 @@
-package io.kevinlee.pdf2excel
+package pdf2excel
 
 import cats._
 import cats.syntax.all._
@@ -7,7 +7,7 @@ import effectie.core._
 import effectie.resource.ResourceMaker
 import effectie.syntax.all._
 import info.folone.scala.poi.{NumericCell, Row, Sheet, StringCell, Workbook}
-import io.kevinlee.pdf2excel.config.Pdf2ExcelConfig
+import pdf2excel.config.Pdf2ExcelConfig
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.text.PDFTextStripper
 import pureconfig.ConfigReader
@@ -143,10 +143,10 @@ object Pdf2Excel {
         pages    <- convertToText(inputFile, pdfConfig.pdf.fromTo)
         // TODO: get it from parameter or config file
         //    val maybeDoc: Option[TransactionDoc] = handlePages(PageHandler1, pages)
-        //    val maybeDoc: Option[TransactionDoc] = handlePages(io.kevinlee.pdf2excel.cba.CbaPageHandler2, none[TransactionDoc => TransactionDoc], pages)
+        //    val maybeDoc: Option[TransactionDoc] = handlePages(pdf2excel.cba.CbaPageHandler2, none[TransactionDoc => TransactionDoc], pages)
         maybeDoc <- handlePages(
-                      io.kevinlee.pdf2excel.ing.IngPageHandler,
-                      (io.kevinlee.pdf2excel.ing.IngPageHandler.postProcess _).some,
+                      pdf2excel.ing.IngPageHandler,
+                      (pdf2excel.ing.IngPageHandler.postProcess _).some,
                       pages,
                     )
         _        <- maybeDoc match {

--- a/src/main/scala/pdf2excel/Pdf2ExcelApp.scala
+++ b/src/main/scala/pdf2excel/Pdf2ExcelApp.scala
@@ -1,11 +1,11 @@
-package io.kevinlee.pdf2excel
+package pdf2excel
 
 import cats.effect.{IO, IOApp}
 import cats.syntax.all._
 import effectie.instances.ce2.fx._
 import effectie.resource.{Ce2ResourceMaker, ResourceMaker}
 import extras.cats.syntax.all._
-import io.kevinlee.pdf2excel.config.Pdf2ExcelConfig
+import pdf2excel.config.Pdf2ExcelConfig
 
 import java.io.File
 

--- a/src/main/scala/pdf2excel/cba/CbaPageHandler.scala
+++ b/src/main/scala/pdf2excel/cba/CbaPageHandler.scala
@@ -1,11 +1,11 @@
-package io.kevinlee.pdf2excel.cba
+package pdf2excel.cba
 
 import cats.parse.Parser.{Error => ParserError}
 import cats.parse.{Parser => P}
 import cats.syntax.all._
 import com.github.nscala_time.time.Imports.LocalDate
-import io.kevinlee.parsers.Parsers._
-import io.kevinlee.pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
+import kevinlee.parsers.Parsers._
+import pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/pdf2excel/cba/CbaPageHandler2.scala
+++ b/src/main/scala/pdf2excel/cba/CbaPageHandler2.scala
@@ -1,11 +1,11 @@
-package io.kevinlee.pdf2excel.cba
+package pdf2excel.cba
 
 import cats.parse.Parser.{Error => ParserError}
 import cats.parse.{Parser => P}
 import cats.syntax.all._
 import com.github.nscala_time.time.Imports.LocalDate
-import io.kevinlee.parsers.Parsers._
-import io.kevinlee.pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
+import kevinlee.parsers.Parsers._
+import pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/pdf2excel/config/Pdf2ExcelConfig.scala
+++ b/src/main/scala/pdf2excel/config/Pdf2ExcelConfig.scala
@@ -1,9 +1,9 @@
-package io.kevinlee.pdf2excel.config
+package pdf2excel.config
 
 import effectie.core.Fx
 import effectie.syntax.all._
-import io.kevinlee.pdf2excel.Pdf2Excel.FromTo
-import io.kevinlee.pdf2excel.config.Pdf2ExcelConfig.{ExcelConfig, PdfConfig}
+import pdf2excel.Pdf2Excel.FromTo
+import pdf2excel.config.Pdf2ExcelConfig.{ExcelConfig, PdfConfig}
 import pureconfig.ConfigReader.Result
 import pureconfig.{ConfigReader, ConfigSource}
 

--- a/src/main/scala/pdf2excel/data.scala
+++ b/src/main/scala/pdf2excel/data.scala
@@ -1,4 +1,4 @@
-package io.kevinlee.pdf2excel
+package pdf2excel
 
 import com.github.nscala_time.time.Imports.LocalDate
 

--- a/src/main/scala/pdf2excel/ing/IngPageHandler.scala
+++ b/src/main/scala/pdf2excel/ing/IngPageHandler.scala
@@ -1,11 +1,11 @@
-package io.kevinlee.pdf2excel.ing
+package pdf2excel.ing
 
 import cats.parse.Parser.{Error => ParserError}
 import cats.parse.{Parser => P}
 import cats.syntax.all._
 import com.github.nscala_time.time.Imports.LocalDate
-import io.kevinlee.parsers.Parsers._
-import io.kevinlee.pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
+import kevinlee.parsers.Parsers._
+import pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/pdf2excel/nab/NabPageHandler.scala
+++ b/src/main/scala/pdf2excel/nab/NabPageHandler.scala
@@ -1,10 +1,10 @@
-package io.kevinlee.pdf2excel.nab
+package pdf2excel.nab
 
 import cats.parse.{Parser => P}
 import cats.syntax.all._
 import com.github.nscala_time.time.Imports.LocalDate
-import io.kevinlee.parsers.Parsers.{alphabets, digits, monetaryNumbers, spaces, stringChars}
-import io.kevinlee.pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
+import kevinlee.parsers.Parsers.{alphabets, digits, monetaryNumbers, spaces, stringChars}
+import pdf2excel.{Header, PageHandler, Transaction, TransactionDoc}
 
 /** @author Kevin Lee
   * @since 2018-09-30


### PR DESCRIPTION
Rename packages `io.kevinlee.parsers` => `kevinlee.parsers` / `io.kevinlee.pdf2excel` => `pdf2excel`