### PR TITLE
Refactor: Provide the default method body for `def getPostProcess: Option[A => A]` which just returns `None`

### DIFF
--- a/src/main/scala/pdf2excel/cba/CbaPageHandler.scala
+++ b/src/main/scala/pdf2excel/cba/CbaPageHandler.scala
@@ -118,5 +118,4 @@ case object CbaPageHandler extends PageHandler[TransactionDoc] {
     }
   }
 
-  override val getPostProcess: Option[TransactionDoc => TransactionDoc] = none
 }

--- a/src/main/scala/pdf2excel/cba/CbaPageHandler2.scala
+++ b/src/main/scala/pdf2excel/cba/CbaPageHandler2.scala
@@ -135,5 +135,4 @@ case object CbaPageHandler2 extends PageHandler[TransactionDoc] {
     }
   }
 
-  override val getPostProcess: Option[TransactionDoc => TransactionDoc] = none
 }

--- a/src/main/scala/pdf2excel/data.scala
+++ b/src/main/scala/pdf2excel/data.scala
@@ -1,12 +1,13 @@
 package pdf2excel
 
+import cats.syntax.all.*
 import com.github.nscala_time.time.Imports.LocalDate
 
 /** @author Kevin Lee
   * @since 2018-09-30
   */
 trait PageHandler[A] extends (List[String] => Option[A]) {
-  def getPostProcess: Option[A => A]
+  def getPostProcess: Option[A => A] = none
 }
 
 final case class Header(

--- a/src/main/scala/pdf2excel/nab/NabPageHandler.scala
+++ b/src/main/scala/pdf2excel/nab/NabPageHandler.scala
@@ -63,5 +63,4 @@ case object NabPageHandler extends PageHandler[TransactionDoc] {
     }
   }
 
-  override val getPostProcess: Option[TransactionDoc => TransactionDoc] = none
 }


### PR DESCRIPTION
Refactor: Provide the default method body for `def getPostProcess: Option[A => A]` which just returns `None`